### PR TITLE
Fixes compilation error for Java 8

### DIFF
--- a/src/main/java/moneytransferapp/MoneyTransferWorkflowImpl.java
+++ b/src/main/java/moneytransferapp/MoneyTransferWorkflowImpl.java
@@ -26,7 +26,7 @@ public class MoneyTransferWorkflowImpl implements MoneyTransferWorkflow {
             .setRetryOptions(retryoptions)
             .build();
     // ActivityStubs enable calls to methods as if the Activity object is local, but actually perform an RPC.
-    private final Map<String, ActivityOptions> perActivityMethodOptions = new HashMap<>(){{
+    private final Map<String, ActivityOptions> perActivityMethodOptions = new HashMap<String, ActivityOptions>(){{
         put(WITHDRAW, ActivityOptions.newBuilder().setHeartbeatTimeout(Duration.ofSeconds(5)).build());
     }};
     private final AccountActivity account = Workflow.newActivityStub(AccountActivity.class, defaultActivityOptions, perActivityMethodOptions);


### PR DESCRIPTION
## What was changed
Hi Guys!

I recently started playing with temporal, and I found this small issue while running the app on an older version of java. 
I didn't see a minimum version in the `build.gradle` so I assumed it's supposed to be working. 

Lemme know if I can add anything to PR!

1. Closes 
None

2. How was this tested:
Manually, compile using `./gradlew build`

3. Any docs updates needed?
None

![image](https://user-images.githubusercontent.com/1883766/140236747-7938287e-5ecf-4eca-9dde-d593e61376b3.png)
