### PR TITLE
Bump gradle version to fix build error "Unsupported class file major v…

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
…ersion 63" and fix bug https://github.com/temporalio/money-transfer-project-template-java/issues/17.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Bumped gradle version.

## Why?
Building existing checkout from scratch caused a "Unsupported class file major version 63" crash.

## Checklist
<!--- add/delete as needed --->

1. Closes Issue 17

2. How was this tested:
Run ./gradlew build
