### PR TITLE
Upgrade Gradle for compatibility with recent SDKs

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## What was changed
Upgrades version of Gradle from 7.6 to 8.5.

## Why?
The current version is not compatible with recent JDK releases, as detailed in [issue #26](https://github.com/temporalio/money-transfer-project-template-java/issues/26)

## Checklist
1. Closes [issue #26](https://github.com/temporalio/money-transfer-project-template-java/issues/26)

2. How was this tested:
Prior to the change, I could not build with JDK 21. 

After making this change locally, I verified that I could successfully build with both JDK 21 and 11 (the only two versions I have installed). 

3. Any docs updates needed?
No
